### PR TITLE
Added a ImmutableJs helper for merging state with a delete

### DIFF
--- a/src/__tests__/immutable/mergeDeleteSuccess.spec.js
+++ b/src/__tests__/immutable/mergeDeleteSuccess.spec.js
@@ -1,0 +1,71 @@
+import {fromJS, is, OrderedMap, List, Map} from 'immutable';
+import ImmtuableUtils from '../../immutable';
+
+describe('mergeDeleteSuccess function', () => {
+
+    const state = fromJS({
+        fetching: true,
+        error: false,
+        entities: {
+            media: {
+                '18959': {
+                    original_file_name: 'Screen Shot 2017-07-13 at 11.05.25 am.png',
+                    size: '268082',
+                    path: 'media',
+                    mime_type: 'image/png',
+                    created_at: 1499918354000,
+                    file_name: '1499918351_z60bx_.png',
+                    url: '//d27jjb85n91zzw.cloudfront.net/media/1499918351_z60bx_.png',
+                    parent_id: 69933,
+                    updated_at: 1499918354000,
+                    id: 18959
+                }
+            },
+            countries: {
+                22: {id: 22, title: 'Ethiopia'},
+                44: {id: 44, title: 'Botswana'},
+                55: {id: 55, title: 'Argentina'},
+            },
+            continents: {
+                12: {id: 12, title: 'Africa'},
+                7: {id: 7, title: 'South America'},
+            }
+        },
+        result: 298,
+    });
+
+    const actual = ImmtuableUtils.mergeDeleteSuccess(state, {
+        data: {
+            entities: {
+                countries: {
+                    22: {id: 22, title: 'Ethiopia', population: 99390000, size: '1.104m km2',},
+                },
+                continents: {
+                    12: {id: 12, title: 'Africa', countries: 54,},
+                }
+            },
+            result: 22,
+        },
+    }, 'media');
+
+    const expected = fromJS({
+        fetching: false,
+        error: false,
+        entities: {
+            countries: {
+                22: {id: 22, title: 'Ethiopia', population: 99390000, size: '1.104m km2',},
+                44: {id: 44, title: 'Botswana'},
+                55: {id: 55, title: 'Argentina'},
+            },
+            continents: {
+                12: {id: 12, title: 'Africa', countries: 54,},
+                7: {id: 7, title: 'South America'},
+            }
+        },
+        result: 22,
+    });
+
+    it('returns correct success state', () => {
+        expect(is(actual, expected)).toBe(true);
+    });
+});

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -73,6 +73,19 @@ function mergeSuccess(state, payload) {
 }
 
 /**
+ * Merges a modules state on success action including a delete action
+ * @return Object
+ */
+function mergeDeleteSuccess(state, payload, deleted) {
+    return state
+        .set('fetching', false)
+        .set('error', false)
+        .deleteIn(['entities', deleted])
+        .update('entities', entities => entities.mergeDeep(payload.data.entities))
+        .update('result', result => payload && payload.data && payload.data.result || false );
+}
+
+/**
  * Merges a modules state on collection success action
  * @return Object
  */
@@ -117,6 +130,7 @@ export default {
   mergeSearchRequest,
   mergeRequest,
   mergeSuccess,
+  mergeDeleteSuccess,
   mergeCollectionSuccess,
   mergeFailure,
   createOrderedMap,


### PR DESCRIPTION
I couldn't work out a good way to merge the state of the media attachments when there an attachment has been removed as merging a set with the empty set will always return the initial set. 

This provides a way to delete keys from the state as part of a reducer processing. Does that work? 