### PR TITLE
Feature/prevent order from getting lost when merging state

### DIFF
--- a/src/__tests__/immutable/mergeCollectionSuccess.spec.js
+++ b/src/__tests__/immutable/mergeCollectionSuccess.spec.js
@@ -1,5 +1,5 @@
-import { fromJS, is, OrderedMap, List, Set, Map } from 'immutable';
-import ImmtuableUtils from '../../immutable';
+import { fromJS, is, isOrdered, OrderedMap, List, Set, OrderedSet, Map } from 'immutable';
+import ImmutableUtils from '../../immutable';
 
 describe('mergeCollectionSuccess function', () => {
 
@@ -13,16 +13,17 @@ describe('mergeCollectionSuccess function', () => {
         55: { id: 55, title: 'Argentina' },
         66: { id: 66, title: 'Sudan' },
         77: { id: 77, title: 'Chile' },
+        11: {id: 11, title: 'Australia'}
       },
       continents: {
         12: { id: 12, title: 'Africa' },
         7: { id: 7, title: 'South America' },
       }
     },
-    results: Set([22,44,55,66,77]),
+    results: [22,11,55,44,66,77],
   });
 
-  const actual = ImmtuableUtils.mergeCollectionSuccess(state, {
+  const actual = ImmutableUtils.mergeCollectionSuccess(state, {
     data: {
       entities: {
         countries: {
@@ -35,7 +36,7 @@ describe('mergeCollectionSuccess function', () => {
           12: { id: 12, title: 'Europe' },
         }
       },
-      result: Set([122,66,88]),
+      result: [88,122,66],
     },
   });
 
@@ -44,9 +45,14 @@ describe('mergeCollectionSuccess function', () => {
     expect(actual.get('error')).toBe(false);
   });
 
+  it('it maintains the result order', () => {
+    expect(isOrdered(actual.get('results'))).toBe(true);
+  });
+
   it('returns correct entities state', () => {
     const expected = fromJS({
       countries: {
+        11: {id: 11, title: 'Australia'},
         22: { id: 22, title: 'Ethiopia' },
         44: { id: 44, title: 'Botswana' },
         55: { id: 55, title: 'Argentina' },
@@ -65,7 +71,8 @@ describe('mergeCollectionSuccess function', () => {
   });
 
   it('returns correct results state', () => {
-    const expected = Set([22,44,55,66,77,122,88]);
+    const expected = OrderedSet([22,11,55,44,66,77,88,122]);
+
     expect(is(actual.get('results'), expected)).toBe(true);
   });
 });

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -74,16 +74,20 @@ function mergeSuccess(state, payload) {
 
 /**
  * Merges a modules state on collection success action
+ *
+ * Maintains the order of the results.
+ *
  * @return Object
  */
 function mergeCollectionSuccess(state, payload) {
+
   return state
     .set('fetching', false)
     .set('error', false)
     .update('entities', entities => entities.mergeDeep(payload.data.entities))
     .update('results', results => {
-      const payloadResult = Immutable.Set(payload && payload.data && payload.data.result, Immutable.Set());
-      const resultsSet = Immutable.Set.isSet(results) ? results : results.toSet();
+      const payloadResult = Immutable.OrderedSet(payload && payload.data && payload.data.result || OrderedSet());
+      const resultsSet = Immutable.OrderedSet.isOrderedSet(results) ? results : results.toOrderedSet();
       return resultsSet.union(payloadResult);
     });
 }


### PR DESCRIPTION
Fix for the order getting lost when merging collection state. Use an Immutable.js OrderedSet instead of a Set. 

https://facebook.github.io/immutable-js/docs/#/OrderedSet

I'm not 100% on whether we should be taking the union of the two sets in the way that we are at the moment, but since the behaviour is quite central to our application I don't want to modify it too much. I imagine we might be using it to save on operations when updating the store somewhere else in the application. 

However, I think that reducing the state of a search operation should entirely replace the results list instead of merging in the state. 