### PR TITLE
Reverted set union in the Merge Collection reducer function

### DIFF
--- a/src/__tests__/immutable/mergeCollectionSuccess.spec.js
+++ b/src/__tests__/immutable/mergeCollectionSuccess.spec.js
@@ -71,7 +71,7 @@ describe('mergeCollectionSuccess function', () => {
   });
 
   it('returns correct results state', () => {
-    const expected = OrderedSet([22,11,55,44,66,77,88,122]);
+    const expected = OrderedSet([88,122,66]);
 
     expect(is(actual.get('results'), expected)).toBe(true);
   });

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -86,9 +86,7 @@ function mergeCollectionSuccess(state, payload) {
     .set('error', false)
     .update('entities', entities => entities.mergeDeep(payload.data.entities))
     .update('results', results => {
-      const payloadResult = Immutable.OrderedSet(payload && payload.data && payload.data.result || OrderedSet());
-      const resultsSet = Immutable.OrderedSet.isOrderedSet(results) ? results : results.toOrderedSet();
-      return resultsSet.union(payloadResult);
+      return Immutable.OrderedSet(payload && payload.data && payload.data.result || OrderedSet());
     });
 }
 


### PR DESCRIPTION
In # 0.2.25, results were changed from using Immutable.List to using Immutable.Set.
Part of this change was merging the Payload with the existing state using Immutable.Set.union However, I don't think this has the desired effect. 

When querying the API and returning the results, you'd expect the order of the API to be maintained throughout the process.
However, if there are entities in the state results that also match the incoming payload, the outcome of the union will be inconsistent with the API.
This causes the state to be populated with a different state to what is returned from the API and in my opinion an incorrect one.