### PR TITLE
Revert "Reverted set union in the Merge Collection reducer function"

### DIFF
--- a/src/__tests__/immutable/mergeCollectionSuccess.spec.js
+++ b/src/__tests__/immutable/mergeCollectionSuccess.spec.js
@@ -71,7 +71,7 @@ describe('mergeCollectionSuccess function', () => {
   });
 
   it('returns correct results state', () => {
-    const expected = OrderedSet([88,122,66]);
+    const expected = OrderedSet([22,11,55,44,66,77,88,122]);
 
     expect(is(actual.get('results'), expected)).toBe(true);
   });

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -86,7 +86,9 @@ function mergeCollectionSuccess(state, payload) {
     .set('error', false)
     .update('entities', entities => entities.mergeDeep(payload.data.entities))
     .update('results', results => {
-      return Immutable.OrderedSet(payload && payload.data && payload.data.result || OrderedSet());
+      const payloadResult = Immutable.OrderedSet(payload && payload.data && payload.data.result || OrderedSet());
+      const resultsSet = Immutable.OrderedSet.isOrderedSet(results) ? results : results.toOrderedSet();
+      return resultsSet.union(payloadResult);
     });
 }
 


### PR DESCRIPTION
In 0.2.25, results were changed from using Immutable.List to using Immutable.Set. Part of this change was merging the Payload with the existing state using Immutable.Set.union. 

I reverted this change in 0.2.34 because I thought that this behaviour was unintentional. However I found the use case for which it was originally implemented which is where we want to retrieve and hydrate the store using multiple requests. In the case I identified, on the organisation dashboard we are doing multiple requests to populate the store with expired, pending and live jobs. We can then retrieve them all from the store maintaining their individual orders with respect to the API but we avoid having to duplicate the jobs in the store, i.e. they are normalised and order is persisted by the results array.  

I think the solution to the problem with the mobile site that this commit was meant to get around should be to clear the results array when searching again as we do not want to merge the results array only the entities in this case. 

This reverts commit 96c998f5d2a798c552f3ad63f58503209821d678.